### PR TITLE
Fix issue 1

### DIFF
--- a/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
@@ -60,13 +60,13 @@ public class IexRestControllerTest extends ASpringTest {
 
     MvcResult result = this.mvc.perform(
         org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-            .get("/iex/lastTradedPrice?symbols=AAPL")
+            .get("/iex/lastTradedPrice?symbols=FB")
             // This URL will be hit by the MockMvc client. The result is configured in the file
             // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
             .accept(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$[0].symbol", is("FB")))
-        .andExpect(jsonPath("$[0].price").value(new BigDecimal("186.34")))
+        .andExpect(jsonPath("$[0].price").value(new BigDecimal("186.3011")))
         .andReturn();
   }
 

--- a/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
+++ b/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
@@ -6,7 +6,7 @@
     "method" : "GET"
   },
   "response" : {
-    "status" : 404,
+    "status" : 200,
     "jsonBody" : [{"symbol":"FB","price":186.3011,"size":100,"time":1565273330617}],
     "headers" : {
       "Server" : "nginx",


### PR DESCRIPTION
### Design
- Changed FB wiremock mapping to status 200.
- Changed endpoint query to FB in test
- Changed expected price to match wiremock mapping for FB

### Test Evidence
<img width="230" alt="image" src="https://user-images.githubusercontent.com/43644172/175282423-9f0bcf4e-d5d6-4d6e-8915-2a5d853303fd.png">
